### PR TITLE
gee_test_tag直接返回html_safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ GeeTest.app_key = 'xx'
 在eruby中使用
 
 ```eruby
-<%== GeeTest.gee_test_tag(product: 'embed') %>
+<%= GeeTest.gee_test_tag(product: 'embed') %>
 ```
 
 在controller中验证

--- a/lib/gee_test.rb
+++ b/lib/gee_test.rb
@@ -32,7 +32,7 @@ module GeeTest
 
     def gee_test_tag config={}
       config = {gt: app_id}.merge config
-      "<script type='text/javascript' src='http://api.geetest.com/get.php?#{config.to_query}'></script>"
+      "<script type='text/javascript' src='http://api.geetest.com/get.php?#{config.to_query}'></script>".html_safe
     end
   end
 end


### PR DESCRIPTION
gee_test_tag直接返回html_safe,
view中使用<%= gee_test_tag %>来替代<%== gee_test_tag %>

@xiajian 
😄 没有问题的话，你来bump一个新版本？
